### PR TITLE
Update light theme to properly display default colors & buttons

### DIFF
--- a/app/scss/partials/custom_components/_footer.scss
+++ b/app/scss/partials/custom_components/_footer.scss
@@ -69,7 +69,8 @@ $flogo-width: rem-calc(212) / 1.5;
 // Footer Button Style
 .global-footer{
 	.footer-button{
-		border: 2px solid;
+		border: 2px solid $black;
+		color: $black;
 		font-size: rem-calc(15);
 		padding: rem-calc(14 48 15 48);
 		border-radius: rem-calc(50);

--- a/app/scss/partials/custom_components/_main-content.scss
+++ b/app/scss/partials/custom_components/_main-content.scss
@@ -8,6 +8,7 @@
 // Main Content items wrapper
 .is-content, .BoxFilter, .BoxButtons, .BoxCategories, .Box{
 	box-shadow: 0px 2px 0px 0px rgba($black, 0.2);
+	background: $seashell;
 	margin-bottom: rem-calc(30);
   border-radius: rem-calc(2);
 }

--- a/app/scss/partials/custom_components/_popup.scss
+++ b/app/scss/partials/custom_components/_popup.scss
@@ -11,8 +11,8 @@
       width: 100%;
     }
     .Body{
-      border-top: rem-calc(15) solid;
-      border-bottom: rem-calc(15) solid;
+      border-top: rem-calc(15) solid $white;
+      border-bottom: rem-calc(15) solid $white;
       overflow-y: auto;
       max-height: calc(100vh - 175px);
       border-radius: rem-calc(4);
@@ -159,18 +159,15 @@
         line-height: rem-calc(34);
         font-weight: 300;
       }
-      form div{
-        margin: rem-calc(0 25);
-      }
       .Entry{
         margin: 0;
       }
       .Buttons{
         flex-direction: column;
         justify-content: flex-start;
-        margin: 0;
+        margin: rem-calc(0 25);
         .Button.Primary{
-          width: rem-calc(90);
+          width: rem-calc(125);
         }
         .CheckBoxLabel{
           display: flex;

--- a/app/scss/partials/foundation_components/_buttons.scss
+++ b/app/scss/partials/foundation_components/_buttons.scss
@@ -36,21 +36,6 @@
   @include button-size($full-width: true);
 }
 
-%btn{
-  box-sizing: border-box;
-  background: transparent;
-  text-transform: uppercase;
-  border: 2px solid;
-  border-radius: rem-calc(4);
-  text-shadow: none;
-  box-shadow: none;
-  margin-top: rem-calc(20);
-  font-weight: 300;
-  font-size: rem-calc(14);
-  padding: rem-calc(4 20 6);
-  line-height: rem-calc(22);
-}
-
 %mobile-btn{
   @media #{$small-only} {
     width: 100%;
@@ -62,20 +47,10 @@
 .BigButton.NewConversation,
 .BigButton.Popup,
 .BigButton.ClearConversation{
-  @extend %btn;
   line-height: rem-calc(34);
-	margin: rem-calc(30);
+  margin: rem-calc(30);
 	width: calc(100% - #{rem-calc(60)});
   @extend %mobile-btn;
-}
-
-.Button.SignInPopup,
-.Button.ApplyButton{
-  @extend %btn;
-  margin: 0;
-  &.ApplyButton{
-    margin-left: rem-calc(15);
-  }
 }
 
 // General Button Styling
@@ -86,8 +61,6 @@
   .Buttons{
     text-align: left;
     .Button{
-      @extend %btn;
-      margin-top: 0;
       @extend %mobile-btn;
     }
   }
@@ -122,7 +95,7 @@ body.Section-ConversationList.inbox{
       margin-right: auto;
     }
     .Button{
-      height: rem-calc(40);
+      height: rem-calc(50);
       @media #{$small-only}{
         width: 100%;
         margin: rem-calc(5 0);
@@ -230,7 +203,6 @@ body.Section-ConversationList.inbox{
   }
   .Buttons, p{
     .Button{
-      @extend %btn;
       @extend %mobile-btn;
     }
   }
@@ -247,56 +219,18 @@ body.Section-ConversationList.inbox{
   }
 }
 
-.GuestBox{
-  .P .Primary{
-    @extend %btn;
-  }
-}
-
 // Profile Ignore Button
 .Profile.ignore{
   .IgnoreUserAction{
     .Ignore{
-      @extend %btn;
       @extend %mobile-btn;
     }
   }
 }
 
 // Discussion Polls Buttons
-#DP_NextQuestion, #DP_AddOption{
-  @extend %btn;
-}
 #DP_AddOption{
   margin-left: rem-calc(15);
-}
-.DP_AnswerForm{
-  .Buttons{
-    .Button{
-      @extend %btn;
-    }
-  }
-}
-
-// Admin Sign In
-#Form_User_SignIn{
-  .Buttons .Button{
-    @extend %btn;
-  }
-}
-
-// Js Connect Button
-.connect .Connect{
-  .ButtonContainer .Button{
-    @extend %btn;
-  }
-}
-
-// Sign in Js Connect buttons
-.signin .MultipleEntryMethods{
-  .Button{
-    @extend %btn;
-  }
 }
 
 // End Custom styles ////////////////////////////////////////////////////////////

--- a/app/scss/theme_options/dark/_settings.scss
+++ b/app/scss/theme_options/dark/_settings.scss
@@ -15,7 +15,7 @@ $body-background: $lightblack;
 // Top Bar
 $tab-bar-background: $onyx;
 $tab-bar-logo: '/themes/sanmyaku/design/images/#{$theme-name}/vanilla-logo.png';
-$logo-width: 100px;
+$logo-width: 6.25rem; // 100px
 $profile-photo-border: $midnight-blue;
 
 // Off canvas

--- a/app/scss/theme_options/modules/_buttons.scss
+++ b/app/scss/theme_options/modules/_buttons.scss
@@ -7,3 +7,18 @@
   border-color: $border;
   color: $color;
 }
+
+%btn{
+  box-sizing: border-box;
+  background: transparent;
+  text-transform: uppercase;
+  border: 2px solid;
+  border-radius: 0.25rem;
+  text-shadow: none;
+  box-shadow: none;
+  margin-top: 1.25rem;
+  font-weight: 300;
+  font-size: 0.875rem;
+  padding: 0.5rem 1.25rem 0.375rem;
+  line-height: 1.375rem;
+}

--- a/app/scss/theme_options/shared/_buttons.scss
+++ b/app/scss/theme_options/shared/_buttons.scss
@@ -8,7 +8,29 @@
 .Button.NewConversation,
 .BigButton.Popup,
 .BigButton.ClearConversation{
+  @extend %btn;
+  margin: 1.875rem;
   @extend %primary-btn;
+}
+
+// Sign In
+.Button{
+  &.SignInPopup, &.ApplyButton{
+    @extend %btn;
+    margin: 0;
+  }
+  &.ApplyButton{
+    margin-left: 0.9375;
+  }
+}
+
+// General Button Styling
+.DataListWrap, .FormWrapper,
+.AddPeople, .Popup{
+  .Buttons .Button{
+    @extend %btn;
+    margin-top: 0;
+  }
 }
 
 // General Button Colors
@@ -40,6 +62,9 @@ body.inbox{
 // Form Buttons
 .FormWrapper{
   .Buttons{
+    .Button{
+      height: 2.5rem;
+    }
     .CommentButton, .DiscussionButton{
       border-color: $primary-btn-border;
     }
@@ -88,6 +113,7 @@ body.inbox{
 .Profile.Section-EditProfile, .signin, .register{
   .Buttons, p{
     .Button{
+      @extend %btn;
       @extend %secondary-btn;
     }
   }
@@ -102,6 +128,7 @@ body.inbox{
 
 // SSO Sign in btn
 .GuestBox .P .Primary{
+  @extend %btn;
   @extend %secondary-btn;
 }
 
@@ -126,6 +153,7 @@ body.inbox{
 .Profile.ignore{
   .IgnoreUserAction{
     .Ignore{
+      @extend %btn;
       @extend %secondary-btn;
     }
   }
@@ -142,11 +170,13 @@ body.inbox{
 
 // Discussion Polls Button
 #DP_NextQuestion, #DP_AddOption{
+  @extend %btn;
   @extend %gray-btn;
 }
 .DP_AnswerForm{
   .Buttons{
     .Button{
+      @extend %btn;
       @extend %secondary-btn;
     }
   }
@@ -162,6 +192,7 @@ body.inbox{
 // Admin SignIn
 #Form_User_SignIn{
   .Buttons .Button{
+    @extend %btn;
     @extend %secondary-btn;
   }
 }
@@ -169,6 +200,14 @@ body.inbox{
 // Js Connect
 .connect .Connect{
   .ButtonContainer .Button{
+    @extend %btn;
     @extend %secondary-btn;
+  }
+}
+
+// Sign in Js Connect Buttons
+.signin .MultipleEntryMethods{
+  .Button{
+    @extend %btn;
   }
 }

--- a/app/scss/theme_options/shared/_footer.scss
+++ b/app/scss/theme_options/shared/_footer.scss
@@ -8,7 +8,7 @@
 .global-footer{
 	.footer-main{
 		background: $footer-main-background;
-		@media screen and (min-width: 770px){
+		@media screen and (min-width: 48.13rem){
 			background: $footer-main-background url($footer-background-image) no-repeat center;
 		}
 	}

--- a/app/scss/theme_options/shared/_off-canvas.scss
+++ b/app/scss/theme_options/shared/_off-canvas.scss
@@ -79,7 +79,7 @@
 	.off-canvas-list{
 		a{
 			color: $paragraph-text;
-			padding: rem-calc(8 0 8 37);
+			padding: 0.5rem 0 0.5rem 2.313rem;
 			&:hover{
 				color: $white;
 				background: $side-nav-bg-hover;

--- a/app/scss/theme_options/shared/_popup.scss
+++ b/app/scss/theme_options/shared/_popup.scss
@@ -77,6 +77,9 @@
         }
       }
       .Buttons{
+        .Button.Primary{
+          width: 5.625rem;
+        }
         .CreateAccount{
           color: $paragraph-text;
           a{


### PR DESCRIPTION
Add the default foundation colors/buttons back into the default theme.
Change `px` to `rem` in theme specific files, since `rem-calc()` is not imported in.