### PR TITLE
Add custom Smarty function that exposes Vanillas smartAsset function

### DIFF
--- a/SmartyPlugins/function.smart_asset.php
+++ b/SmartyPlugins/function.smart_asset.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Takes the path to an asset file and prepends the web root.
+ *
+ * @param array $Params The parameters passed into the function. Following parameters are supported:
+ *   string      "destination":  The subpath of the asset.
+ *   bool|string "withdomain":   Whether or not to include the domain in the final URL.
+ *   bool        "addversion":   Whether or not to add a cache-busting version querystring parameter to the URL.
+ * @param Smarty $Smarty The smarty object rendering the template.
+ *
+ * @return string Returns the URL of the asset.
+ */
+function smarty_function_smart_asset($Params, &$Smarty) {
+    return smartAsset(
+        val('destination', $Params, ''),
+        val('withdomain', $Params, false),
+        val('addversion', $Params, false)
+    );
+}

--- a/views/default.master.tpl
+++ b/views/default.master.tpl
@@ -13,7 +13,7 @@
       <nav class="tab-bar">
 
         <section class="left-small left-off-canvas-toggle">
-          <img class="hamburger" src="/themes/sanmyaku/design/images/open-menu.svg" alt="">
+          <img class="hamburger" src="{smart_asset destination="themes/sanmyaku/design/images/open-menu.svg"}" alt="">
         </section>
 
         <section class="middle tab-bar-section TitleBar">
@@ -31,7 +31,7 @@
           </a>
 
           <section class="right-small right-off-canvas-toggle">
-            <img class="hamburger" src="/themes/sanmyaku/design/images/open-menu.svg" alt="">
+            <img class="hamburger" src="{smart_asset destination="themes/sanmyaku/design/images/open-menu.svg"}" alt="">
           </section>
         </div>
 
@@ -42,7 +42,7 @@
           {register_link}
 
           <section class="right-small">
-            <img class="avatar-placeholder" src="/themes/sanmyaku/design/images/avatar-placeholder.svg" alt="">
+            <img class="avatar-placeholder" src="{smart_asset destination="themes/sanmyaku/design/images/avatar-placeholder.svg"}" alt="">
           </section>
         </div>
         {/if}


### PR DESCRIPTION
The default.master.tpl has image links in it which would fail to show the correct image if a forum is in a subfolder. Vanilla offers helper functions for such a task.
This pull request adds a Smarty function which allows themers to make use of the smartAsset() function.

This could also be used to include other assets, such as css and js files.

I've also changed the default.master.tpl to already use this new Smarty funtion